### PR TITLE
Margin promotion

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -38,6 +38,7 @@ class OrderController extends Controller
         $item->quantity = $quantity;
         $item->price_final = $item->price_unit->multipliedBy($quantity);
         $type = Client::select('type')->where('id',$order->client_id)->first()->type->value;
+        
         if($type != 'wholesale'){
             $item->reduction_amount = $item->price_final->multipliedBy($bestPromotion/100,RoundingMode::DOWN);
         }
@@ -112,8 +113,9 @@ class OrderController extends Controller
         $type = Client::select('type')->where('id',$order->client_id)->first()->type->value;
         $product_category_id = Product::with('categories')->find($product->id);
     
-        if($type != 'Wholesale'){
-              // get le plus gros pourcentage en fonction du type & id_categ
+        if($type == 'normal')
+            return 0;
+        if($type != 'wholesale'){
             $bestPromotion = Promotion::select('percentage')
                 ->whereIn('category_id', $product->categories->pluck('id')->toArray())
                 ->orwhere('type', $type) 
@@ -127,7 +129,7 @@ class OrderController extends Controller
                 ->orderBy('percentage', 'desc')  
                 ->first();
         }
-        return $bestPromotion->percentage;
+        return $bestPromotion ? $bestPromotion->percentage : 0;
     }
 
     protected function getResponse(Request $request, ?Order $order = null): JsonResponse|RedirectResponse

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -6,12 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\EloquentSortable\Sortable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Spatie\EloquentSortable\SortableTrait;
 use Whitecube\Sluggable\HasSlug;
 
 class Category extends Model implements Sortable
 {
-    use HasSlug, SoftDeletes, SortableTrait;
+    use HasSlug, SoftDeletes, SortableTrait, HasFactory;
 
     public array $sortable = [
         'order_column_name' => 'order',

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -6,11 +6,12 @@ use App\Transactions\Clients\ClientType;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Client extends Model
 {
-    use SoftDeletes;
+    use SoftDeletes,HasFactory;
 
     protected $guarded = [];
 

--- a/app/Models/OrderProduct.php
+++ b/app/Models/OrderProduct.php
@@ -25,6 +25,7 @@ class OrderProduct extends Model implements Sortable
         return [
             'price_unit' => Money::class,
             'price_final' => Money::class,
+            'reduction_amount' => Money::class,
         ];
     }
 

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -7,12 +7,13 @@ use App\Models\Traits\FormatsPrices;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Whitecube\Sluggable\HasSlug;
 
 class Product extends Model
 {
-    use FormatsPrices, HasSlug, SoftDeletes;
+    use FormatsPrices, HasSlug, SoftDeletes, HasFactory;
 
     public string $sluggable = 'name';
 

--- a/app/Models/Promotion.php
+++ b/app/Models/Promotion.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use App\Transactions\Clients\ClientType;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Model;
+
+class Promotion extends Model
+{
+    
+    # Une date de début et de fin serait une amélioration possible
+    # La possibilité de lier une promotion à plusieurs groupes client et aussi à plusieurs categories seraient de bonnes améliorations pour faciliter la configuration
+    
+    # On pourrait aussi réfléchir a faire des promotions avec un montant au lieu de pourcentage en ajoutant
+    # une nouvelle colonne 'type' afin de préciser si la réduction est un pourcentage ou un montant. Il faudra renommer la colonne percentage par reduction pour plus de clarté
+    
+    public function category()
+    {
+        return $this->belongsTo(Category::class)->nullable();
+    }
+
+    
+    public function getClientTypeAttribute($value)
+    {
+        return $value ? ClientType::fromValue($value)->label() : null;
+    }
+}

--- a/app/Models/Promotion.php
+++ b/app/Models/Promotion.php
@@ -2,14 +2,21 @@
 
 namespace App\Models;
 
-use App\Transactions\Clients\ClientType;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
 
 class Promotion extends Model
 {
-    
+    use HasFactory;
+
+    protected $fillable = [
+        'percentage',  
+        'category_id', 
+        'type', 
+    ];
     # Une date de début et de fin serait une amélioration possible
     # La possibilité de lier une promotion à plusieurs groupes client et aussi à plusieurs categories seraient de bonnes améliorations pour faciliter la configuration
     

--- a/app/Transactions/Orders/Lines/DeliveryFee.php
+++ b/app/Transactions/Orders/Lines/DeliveryFee.php
@@ -39,7 +39,14 @@ class DeliveryFee implements ReceiptLine
     {
         return Money::of(10, 'EUR');
     }
-
+    public function getReductionAmount(): Money
+    {
+        return Money::of(00, 'EUR');
+    }
+    public function getMargin(): Money
+    {
+        return Money::of(00, 'EUR');
+    }
     public function getDisplayablePrice(): ?string
     {
         return $this->formatPrice($this->getPrice());

--- a/app/Transactions/Orders/Lines/Product.php
+++ b/app/Transactions/Orders/Lines/Product.php
@@ -45,6 +45,11 @@ class Product implements ReceiptLine
         return $this->item->price_final;
     }
 
+    public function getReductionAmount(): Money
+    {
+        return $this->item->reduction_amount;
+    }
+
     public function getDisplayablePrice(): ?string
     {
         return $this->item->formatPrice($this->getPrice());

--- a/app/Transactions/Orders/Lines/Reduction.php
+++ b/app/Transactions/Orders/Lines/Reduction.php
@@ -7,20 +7,16 @@ use App\Transactions\Orders\ReceiptLine;
 use Brick\Money\Money;
 use Illuminate\Support\Collection;
 
-class Subtotal implements ReceiptLine
+class Reduction implements ReceiptLine
 {
     use FormatsPrices;
 
-    protected Money $total;
-    protected Money $margin;
+    protected Money $reduction_amount;
 
     public function __construct(Collection $products)
-    {
-        $this->total = $products->reduce(function (Money $carry, Product $line) {
-            return $carry->plus($line->getPrice());
-        }, Money::zero('EUR'));
-
-        $this->margin = $products->reduce(function (Money $carry, Product $line) {
+    {   
+       
+        $this->reduction_amount = $products->reduce(function (Money $carry, Product $line) {
             return $carry->plus($line->getReductionAmount());
         }, Money::zero('EUR'));
     }
@@ -42,7 +38,7 @@ class Subtotal implements ReceiptLine
 
     public function getLabel(): ?string
     {
-        return 'Sous-total';
+        return 'Remise';
     }
 
     public function getQuantity(): ?int
@@ -52,20 +48,15 @@ class Subtotal implements ReceiptLine
 
     public function getPrice(): Money
     {
-        return $this->total;
+        return Money::of(00, 'EUR');
     }
     public function getReductionAmount(): Money
     {
-        return Money::of(00, 'EUR');
-    }
-
-    public function getMargin(): Money
-    {
-        return $this->margin;
+        return $this->reduction_amount;
     }
     public function getDisplayablePrice(): ?string
     {
-        return $this->formatPrice($this->total);
+        return '- '.$this->formatPrice($this->reduction_amount);
     }
 
     public function getProductAttributes(): array

--- a/app/Transactions/Orders/Lines/Subtotal.php
+++ b/app/Transactions/Orders/Lines/Subtotal.php
@@ -19,10 +19,11 @@ class Subtotal implements ReceiptLine
         $this->total = $products->reduce(function (Money $carry, Product $line) {
             return $carry->plus($line->getPrice());
         }, Money::zero('EUR'));
-
+        
         $this->margin = $products->reduce(function (Money $carry, Product $line) {
             return $carry->plus($line->getReductionAmount());
         }, Money::zero('EUR'));
+        
     }
 
     public function isDisplayable(): bool

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word(), // Un nom aléatoire pour la catégorie
+        ];
+    }
+}

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Client;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Transactions\Clients\ClientType;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Client>
+ */
+class ClientFactory extends Factory
+{
+    protected $model = Client::class;
+
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory(), 
+            'type' => ClientType::Normal->value, // Par défaut, client "Normal"
+        ];
+    }
+
+    public function normal()
+    {
+        return $this->state(fn () => ['type' => ClientType::Normal->value]);
+    }
+
+    public function vip()
+    {
+        return $this->state(fn () => ['type' => ClientType::Vip->value]);
+    }
+
+    public function wholesaler()
+    {
+        return $this->state(fn () => ['type' => ClientType::Wholesaler->value]);
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Product;
+use App\Models\Category;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Product>
+ */
+class ProductFactory extends Factory
+{
+    protected $model = Product::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word(), 
+            'price_selling' => $this->faker->randomFloat(2, 10, 500), 
+            'price_acquisition' => $this->faker->randomFloat(2, 10, 500), 
+            'main_category_id' => Category::factory(), 
+        ];
+    }
+}

--- a/database/factories/PromotionFactory.php
+++ b/database/factories/PromotionFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\Promotion;
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Promotion>
+ */
+class PromotionFactory extends Factory
+{
+    protected $model = Promotion::class;
+
+    public function definition()
+    {
+        return [
+            'percentage' => $this->faker->numberBetween(5, 50), 
+            'category_id' => Category::factory(), 
+            'type' => $this->faker->randomElement([
+                ClientType::Normal->value,
+                ClientType::Vip->value,
+                ClientType::Wholesaler->value,
+            ]), // Type de client
+        ];
+    }
+}

--- a/database/migrations/2025_01_13_102132_create_promotion.php
+++ b/database/migrations/2025_01_13_102132_create_promotion.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Transactions\Clients\ClientType;
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('promotions', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('category_id')->nullable(); 
+            $table->decimal('percentage', 5, 2)->nullable(false);
+            $table->string('type')->nullable();
+            $table->foreign('category_id')->references('id')->on('categories')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2025_01_13_122352_add_reductionamount_to_order_products.php
+++ b/database/migrations/2025_01_13_122352_add_reductionamount_to_order_products.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_products', function (Blueprint $table) {
+            $table->integer('reduction_amount')->unsigned()->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_products', function (Blueprint $table) {
+            $table->dropColumn('reduction_amount');
+        });
+    }
+};

--- a/database/migrations/2025_01_13_122352_add_reductionamount_to_order_products.php
+++ b/database/migrations/2025_01_13_122352_add_reductionamount_to_order_products.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('order_products', function (Blueprint $table) {
-            $table->integer('reduction_amount')->unsigned()->nullable();
+            $table->integer('reduction_amount')->unsigned()->nullable()->default(0);
         });
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             UserSeeder::class,
             ProductSeeder::class,
+            PromotionSeeder::class,
         ]);
     }
 }

--- a/database/seeders/PromotionSeeder.php
+++ b/database/seeders/PromotionSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Transactions\Clients\ClientType;
+use App\Models\Category;
+use App\Models\Promotion;
+
+class PromotionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Insérer promotions sur les catégories
+        Promotion::create([
+            'percentage' => 5.00,
+            'category_id' => Category::where('name', 'Surgelés')->first()->id, 
+            'type' => null 
+        ]);
+
+        Promotion::create([
+            'percentage' => 15.00,
+            'category_id' => Category::where('name', 'Promotions')->first()->id, 
+            'type' => null 
+        ]);
+
+        // Insérer promotions sur les type de clients
+        Promotion::create([
+            'percentage' => 30.00,
+            'category_id' => null, 
+            'type' => ClientType::Wholesaler 
+        ]);
+        
+        Promotion::create([
+            'percentage' => 10.00,
+            'category_id' => null, 
+            'type' =>  ClientType::Vip, 
+        ]);
+    }
+}

--- a/resources/vue/pages/cart.vue
+++ b/resources/vue/pages/cart.vue
@@ -22,6 +22,10 @@
                     :key="item.id"
                     :item="item" />
             </div>
+            <div class="cart__reduction">
+                <p class="title">Reduction</p>
+                <p v-html="reduction"></p>
+            </div>
             <div class="cart__total">
                 <p class="title">Total</p>
                 <p v-html="total"></p>

--- a/tests/Feature/OrderControllerTest.php
+++ b/tests/Feature/OrderControllerTest.php
@@ -1,0 +1,200 @@
+<?php
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Client;
+use App\Models\OrderProduct;
+use App\Models\Order;
+use App\Models\Product;
+use Brick\Money\Money;
+use App\Models\Category;
+use App\Models\Promotion;
+use App\Transactions\Clients\ClientType;
+
+class OrderControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Test that no promotions are applied for normal clients.
+     */
+    public function test_no_promotions_for_normal_clients()
+    {
+       
+        $client = Client::factory()->create([
+            'type' => ClientType::Normal->value, 
+        ]);
+
+  
+        $category = Category::factory()->create(['name' => 'Electronics']);
+        $product = Product::factory()->create([
+            'name' => 'Smartphone',
+            'ref' => 'SMA001',
+            'main_category_id' => $category->id,
+            'price_selling' => 1000.00,
+            'price_acquisition' => 500
+        ]);
+
+      
+        Promotion::create([
+            'category_id' => $category->id,
+            'type' => ClientType::Normal->value, 
+            'percentage' => 20,
+        ]);
+
+       
+        $response = $this->actingAs($client->user)->post('/order', [
+            'id' => $product->id,
+            'quantity' => 2,
+        ]);
+
+    
+        
+        $order = Order::first();
+        $item = $order->products->first();
+      
+        $this->assertEquals(Money::of(0, 'EUR'), $item->reduction_amount);
+    }
+
+    public function test_promotions_for_vip_clients()
+    {
+        $client = Client::factory()->create([
+            'type' => ClientType::Vip->value, 
+        ]);
+
+        $category = Category::factory()->create(['name' => 'Electronics']);
+        $product = Product::factory()->create([
+            'name' => 'Smartphone',
+            'ref' => 'SMA001',
+            'main_category_id' => $category->id,
+            'price_selling' => 1000,
+            'price_acquisition' => 500
+        ]);
+        $percentage = 10;
+        Promotion::create([
+            'category_id' => NULL,
+            'type' => ClientType::Vip->value, // Promotion applicable uniquement aux clients VIP
+            'percentage' =>  $percentage,
+        ]);
+        $promotions = Promotion::all();
+        $quantity = 2;
+        $response = $this->actingAs($client->user)->post('/order', [
+            'id' => $product->id,
+            'user' => $client,
+            'quantity' => $quantity,
+        ]);
+       
+        $orderProduct = OrderProduct::first();
+    
+        $this->assertEquals($product->price_selling->multipliedBy(2)->dividedBy(100/$percentage), $orderProduct->reduction_amount);
+    }
+
+
+    public function test_promotions_for_frozen_category()
+    {
+        $client = Client::factory()->create([
+            'type' => ClientType::Vip->value, 
+        ]);
+
+        $category = Category::factory()->create(['name' => 'Surgelés']);
+        $product = Product::factory()->create([
+            'name' => 'Smartphone froid',
+            'ref' => 'SMA001',
+            'main_category_id' => $category->id,
+            'price_selling' => 1000,
+            'price_acquisition' => 500
+        ]);
+        $percentage = 5;
+        Promotion::create([
+            'category_id' => $category->id, // Promotion applicable uniquement sur la catégorie surgelés
+            'type' => ClientType::Vip->value, 
+            'percentage' => $percentage,
+        ]);
+        $promotions = Promotion::all();
+        $quantity = 2;
+        $response = $this->actingAs($client->user)->post('/order', [
+            'id' => $product->id,
+            'user' => $client,
+            'quantity' => $quantity,
+        ]);
+  
+        $orderProduct = OrderProduct::first();
+      
+        $this->assertEquals($product->price_selling->multipliedBy(2)->dividedBy(100/$percentage), $orderProduct->reduction_amount);
+    }
+
+    public function test_no_promotions_for_frozen_category_and_wholesaler()
+    {
+        $client = Client::factory()->create([
+            'type' => ClientType::Wholesaler->value, 
+        ]);
+
+        $category = Category::factory()->create(['name' => 'Surgelés']);
+        $product = Product::factory()->create([
+            'name' => 'Smartphone froid',
+            'ref' => 'SMA001',
+            'main_category_id' => $category->id,
+            'price_selling' => 1000,
+            'price_acquisition' => 500
+        ]);
+        
+        Promotion::create([
+            'category_id' => $category->id, // Promotion applicable uniquement sur la catégorie surgelés
+            'type' => null, 
+            'percentage' => 5,
+        ]);
+        $promotions = Promotion::all();
+        
+        $response = $this->actingAs($client->user)->post('/order', [
+            'id' => $product->id,
+            'user' => $client,
+            'quantity' => 2,
+        ]);
+  
+        $orderProduct = OrderProduct::first();
+      
+        $this->assertEquals(Money::of(0, 'EUR'), $orderProduct->reduction_amount);
+    }
+
+
+
+    public function test_promotions_for_wholesaler()
+    {
+        $client = Client::factory()->create([
+            'type' => ClientType::Wholesaler->value, 
+        ]);
+
+        $category = Category::factory()->create(['name' => 'Surgelés']);
+
+        $product = Product::factory()->create([
+            'name' => 'Smartphone froid',
+            'ref' => 'SMA001',
+            'main_category_id' => $category->id,
+            'price_selling' => 1000,
+            'price_acquisition' => 500
+        ]);
+        
+        $percentage = 20;
+        Promotion::create([
+            'category_id' => $category->id, // Promotion applicable uniquement sur la catégorie surgelés
+            'type' => ClientType::Wholesaler->value, 
+            'percentage' => $percentage,
+        ]);
+
+        $promotions = Promotion::all();
+        $quantity = 1;
+        $response = $this->actingAs($client->user)->post('/order', [
+            'id' => $product->id,
+            'user' => $client,
+            'quantity' => $quantity,
+        ]);
+  
+        $orderProduct = OrderProduct::first();
+      //  dd($product);
+        //dd($orderProduct);
+
+        $this->assertEquals($product->price_acquisition->multipliedBy($quantity)->dividedBy(100/$percentage), $orderProduct->reduction_amount);
+    }
+
+}


### PR DESCRIPTION
Mon approche a donc été de créer une nouvelle table "promotions".
Elle contient les colonnes id_category , percentage ainsi que le type de client sur lequel la promotion s'applique.

**J'ai noté différentes pistes d'amélioration pour cette fonctionnalité dans le models : "Promotion.php"**

Vu qu'on devait afficher les remises totales dans le panier, j'ai également ajouté un nouveau champ "reduction_amount" dans OrderProduct qui se calcule lorsqu'on ajoute/supprime un produit.
Sauvegarder cette donnée réduit le nombre de traitement car on ne doit pas recalculer les réductions à chaque fois qu'on aura besoin de cette info et cela permet aussi de garder une sorte d'historique sur les réductions qui ont été accordées sur chaque produits dans les différentes commandes.